### PR TITLE
Fix Copilot review comments from merged PRs

### DIFF
--- a/CampusConnect/backend/CampusConnect.API/Controllers/GradesController.cs
+++ b/CampusConnect/backend/CampusConnect.API/Controllers/GradesController.cs
@@ -1,5 +1,6 @@
 using CampusConnect.API.Common;
 using CampusConnect.API.DTOs.Grades;
+using CampusConnect.Application.Common;
 using CampusConnect.Application.Features.Grades;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -29,9 +30,18 @@ public class GradesController(GradesService gradesService) : ControllerBase
         if (userId is null)
             return Unauthorized(new { error = "Benutzer konnte nicht aus dem Token ermittelt werden." });
 
-        var result = await gradesService.GetPlanAsync(userId.Value, cancellationToken);
+        Result<GradePlanDto> result;
+        try
+        {
+            result = await gradesService.GetPlanAsync(userId.Value, cancellationToken);
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Der DHBW-Studienplan konnte aktuell nicht geladen werden." });
+        }
+
         if (!result.IsSuccess)
-            return NotFound(new { error = result.Error });
+            return PlanFailure(result.Error);
 
         return Ok(result.Value);
     }
@@ -62,4 +72,12 @@ public class GradesController(GradesService gradesService) : ControllerBase
     }
 
     private Guid? GetCurrentUserId() => CurrentUser.GetUserId(User);
+
+    private IActionResult PlanFailure(string? error) => error switch
+    {
+        "Benutzerprofil wurde nicht gefunden." => BadRequest(new { error }),
+        "Für dein Profil ist kein gültiger Kurs hinterlegt." => BadRequest(new { error }),
+        "Für deinen Kurs wurde kein DHBW-Studienplan gefunden." => NotFound(new { error }),
+        _ => BadRequest(new { error = error ?? "Der Studienplan konnte nicht geladen werden." })
+    };
 }

--- a/CampusConnect/backend/CampusConnect.Infrastructure/ExternalServices/DhbwStudyPlanProvider.cs
+++ b/CampusConnect/backend/CampusConnect.Infrastructure/ExternalServices/DhbwStudyPlanProvider.cs
@@ -29,9 +29,25 @@ public sealed partial class DhbwStudyPlanProvider(
         return await cache.GetOrCreateAsync(cacheKey, async entry =>
         {
             entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(Math.Max(5, _options.CacheMinutes));
-            await using var stream = await httpClient.GetStreamAsync(source.Url, cancellationToken);
-            return parser.Parse(stream, source.PlanName, source.Url, DateTime.UtcNow);
+            return await FetchPlanAsync(source, cancellationToken);
         });
+    }
+
+    private async Task<StudyPlan?> FetchPlanAsync(DhbwStudyPlanSource source, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var response = await httpClient.GetAsync(source.Url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            return parser.Parse(stream, source.PlanName, source.Url, DateTime.UtcNow);
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
     }
 
     private async Task<DhbwStudyPlanSource?> ResolveSourceAsync(Course course, CancellationToken cancellationToken)
@@ -63,12 +79,31 @@ public sealed partial class DhbwStudyPlanProvider(
 
             foreach (var indexUrl in _options.IndexUrls.Where(url => !string.IsNullOrWhiteSpace(url)))
             {
-                var html = await httpClient.GetStringAsync(indexUrl, cancellationToken);
+                var html = await FetchStringAsync(indexUrl, cancellationToken);
+                if (html is null)
+                    continue;
+
                 sources.AddRange(DhbwStudyPlanIndexParser.Parse(html, new Uri(indexUrl), _options.CampusCode));
             }
 
             return sources;
         }) ?? [];
+    }
+
+    private async Task<string?> FetchStringAsync(string url, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var response = await httpClient.GetAsync(url, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            return await response.Content.ReadAsStringAsync(cancellationToken);
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
     }
 
     private static int Score(string studyProgram, DhbwStudyPlanSource source)

--- a/CampusConnect/backend/CampusConnect.Infrastructure/Repositories/EntityUserRepository.cs
+++ b/CampusConnect/backend/CampusConnect.Infrastructure/Repositories/EntityUserRepository.cs
@@ -17,7 +17,9 @@ public sealed class EntityUserRepository(CampusConnectDbContext dbContext) : IUs
     public async Task<User?> FindByEmailAsync(string email, CancellationToken cancellationToken = default)
     {
         var normalizedEmail = NormalizeEmail(email);
-        return await dbContext.Users.FirstOrDefaultAsync(user => user.Email.ToLower() == normalizedEmail, cancellationToken);
+        return await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(user => user.Email == normalizedEmail, cancellationToken);
     }
 
     public async Task<User?> FindByIdAsync(Guid id, CancellationToken cancellationToken = default) =>

--- a/CampusConnect/backend/CampusConnect.Infrastructure/Repositories/InMemoryGroupRepository.cs
+++ b/CampusConnect/backend/CampusConnect.Infrastructure/Repositories/InMemoryGroupRepository.cs
@@ -1,36 +1,41 @@
 using CampusConnect.Domain.Entities;
 using CampusConnect.Domain.Enums;
 using CampusConnect.Domain.Interfaces;
-using System.Collections.Concurrent;
 
 namespace CampusConnect.Infrastructure.Repositories;
 
 public class InMemoryGroupRepository : IGroupRepository
 {
-    private readonly ConcurrentDictionary<Guid, CampusGroup> _store = new();
-    private readonly object _courseLock = new();
+    private readonly Dictionary<Guid, CampusGroup> _store = [];
+    private readonly object _syncRoot = new();
 
     public Task<IReadOnlyList<CampusGroup>> GetAllAsync()
     {
-        var groups = _store.Values
-            .OrderBy(group => SortKey(group.Type))
-            .ThenBy(group => group.CourseCode ?? group.Name)
-            .Select(Clone)
-            .ToList();
+        lock (_syncRoot)
+        {
+            var groups = _store.Values
+                .OrderBy(group => SortKey(group.Type))
+                .ThenBy(group => group.CourseCode ?? group.Name)
+                .Select(Clone)
+                .ToList();
 
-        return Task.FromResult<IReadOnlyList<CampusGroup>>(groups);
+            return Task.FromResult<IReadOnlyList<CampusGroup>>(groups);
+        }
     }
 
     public Task<CampusGroup?> FindByIdAsync(Guid id)
     {
-        _store.TryGetValue(id, out var group);
-        return Task.FromResult(group is null ? null : Clone(group));
+        lock (_syncRoot)
+        {
+            _store.TryGetValue(id, out var group);
+            return Task.FromResult(group is null ? null : Clone(group));
+        }
     }
 
     public Task<CampusGroup> EnsureCourseGroupAsync(string courseCode, string? studyProgram = null)
     {
         var normalizedCourse = NormalizeCourse(courseCode);
-        lock (_courseLock)
+        lock (_syncRoot)
         {
             var existing = _store.Values.FirstOrDefault(group =>
                 group.Type == GroupType.Course &&
@@ -47,16 +52,24 @@ public class InMemoryGroupRepository : IGroupRepository
 
     public Task AddAsync(CampusGroup group)
     {
-        _store[group.Id] = Clone(group);
+        lock (_syncRoot)
+        {
+            _store[group.Id] = Clone(group);
+        }
+
         return Task.CompletedTask;
     }
 
     public Task UpdateSettingsAsync(Guid id, GroupSettings settings)
     {
-        if (_store.TryGetValue(id, out var group))
+        lock (_syncRoot)
         {
-            group.Settings = Clone(settings);
-            _store[id] = group;
+            if (_store.TryGetValue(id, out var group))
+            {
+                var updated = Clone(group);
+                updated.Settings = Clone(settings);
+                _store[id] = updated;
+            }
         }
 
         return Task.CompletedTask;
@@ -64,11 +77,15 @@ public class InMemoryGroupRepository : IGroupRepository
 
     public Task UpdateAssignmentsAsync(Guid id, IReadOnlyCollection<Guid> assignedUserIds)
     {
-        if (_store.TryGetValue(id, out var group))
+        lock (_syncRoot)
         {
-            group.AssignedUserIds = assignedUserIds.ToHashSet();
-            SyncMemberPermissions(group);
-            _store[id] = group;
+            if (_store.TryGetValue(id, out var group))
+            {
+                var updated = Clone(group);
+                updated.AssignedUserIds = assignedUserIds.ToHashSet();
+                SyncMemberPermissions(updated);
+                _store[id] = updated;
+            }
         }
 
         return Task.CompletedTask;
@@ -76,13 +93,17 @@ public class InMemoryGroupRepository : IGroupRepository
 
     public Task UpdateMemberPermissionsAsync(Guid id, IReadOnlyDictionary<Guid, GroupMemberPermission> permissions)
     {
-        if (_store.TryGetValue(id, out var group))
+        lock (_syncRoot)
         {
-            group.MemberPermissions = group.AssignedUserIds
-                .ToDictionary(
-                    userId => userId,
-                    userId => permissions.TryGetValue(userId, out var permission) ? permission : GroupMemberPermission.ReadWrite);
-            _store[id] = group;
+            if (_store.TryGetValue(id, out var group))
+            {
+                var updated = Clone(group);
+                updated.MemberPermissions = updated.AssignedUserIds
+                    .ToDictionary(
+                        userId => userId,
+                        userId => permissions.TryGetValue(userId, out var permission) ? permission : GroupMemberPermission.ReadWrite);
+                _store[id] = updated;
+            }
         }
 
         return Task.CompletedTask;
@@ -91,15 +112,19 @@ public class InMemoryGroupRepository : IGroupRepository
     public Task SyncCourseAssignmentsAsync(string courseCode, IReadOnlyCollection<Guid> assignedUserIds)
     {
         var normalizedCourse = NormalizeCourse(courseCode);
-        var group = _store.Values.FirstOrDefault(group =>
-            group.Type == GroupType.Course &&
-            string.Equals(group.CourseCode, normalizedCourse, StringComparison.OrdinalIgnoreCase));
-
-        if (group is not null)
+        lock (_syncRoot)
         {
-            group.AssignedUserIds = assignedUserIds.ToHashSet();
-            SyncMemberPermissions(group);
-            _store[group.Id] = group;
+            var group = _store.Values.FirstOrDefault(group =>
+                group.Type == GroupType.Course &&
+                string.Equals(group.CourseCode, normalizedCourse, StringComparison.OrdinalIgnoreCase));
+
+            if (group is not null)
+            {
+                var updated = Clone(group);
+                updated.AssignedUserIds = assignedUserIds.ToHashSet();
+                SyncMemberPermissions(updated);
+                _store[updated.Id] = updated;
+            }
         }
 
         return Task.CompletedTask;

--- a/CampusConnect/frontend/src/app/core/interceptors/error-handler-interceptor.ts
+++ b/CampusConnect/frontend/src/app/core/interceptors/error-handler-interceptor.ts
@@ -1,18 +1,15 @@
 import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
-import { Router } from '@angular/router';
 import { catchError, throwError } from 'rxjs';
 import { Auth } from '../services/auth';
 
 export const errorHandlerInterceptor: HttpInterceptorFn = (req, next) => {
-  const router = inject(Router);
   const auth = inject(Auth);
 
   return next(req).pipe(
     catchError(err => {
       if (err.status === 401) {
         auth.logout();
-        router.navigate(['/login']);
       }
       return throwError(() => err);
     })

--- a/CampusConnect/frontend/src/app/features/auth/login-page/login-page.spec.ts
+++ b/CampusConnect/frontend/src/app/features/auth/login-page/login-page.spec.ts
@@ -1,0 +1,47 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+
+import { Auth } from '../../../core/services/auth';
+import { Courses } from '../../../core/services/courses';
+import { LoginPage } from './login-page';
+
+describe('LoginPage', () => {
+  let component: LoginPage;
+  let fixture: ComponentFixture<LoginPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LoginPage],
+      providers: [
+        provideRouter([]),
+        {
+          provide: Auth,
+          useValue: {
+            login: vi.fn(() => of({ token: 'token', email: 'alice@dhbw-loerrach.de', displayName: 'Alice', role: 'Student' })),
+            register: vi.fn(() => of({ token: 'token', email: 'alice@dhbw-loerrach.de', displayName: 'Alice', role: 'Student' })),
+          },
+        },
+        {
+          provide: Courses,
+          useValue: {
+            getCourses: vi.fn(() => of([{ code: 'TIF25A', studyProgram: 'Informatik', semester: 2 }])),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should preselect the first available course for registration', () => {
+    expect(component['_registerForm'].course).toBe('TIF25A');
+  });
+});

--- a/CampusConnect/frontend/src/app/features/feed/feed-page/feed-page.html
+++ b/CampusConnect/frontend/src/app/features/feed/feed-page/feed-page.html
@@ -95,7 +95,9 @@
           </textarea>
           <div class="composer__footer">
             <span>{{ _newContent().trim().length }}/600 Zeichen</span>
-            <button type="submit" [disabled]="!_newContent().trim() || _isLoading() || !_selectedGroup()">Posten</button>
+            <button type="submit" [disabled]="!_newContent().trim() || _isLoading() || _isPosting() || !_selectedGroup()">
+              {{ _isPosting() ? 'Postet...' : 'Posten' }}
+            </button>
           </div>
         </div>
       </form>

--- a/CampusConnect/frontend/src/app/features/feed/feed-page/feed-page.spec.ts
+++ b/CampusConnect/frontend/src/app/features/feed/feed-page/feed-page.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { signal } from '@angular/core';
+import { WritableSignal, signal } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { FeedPage } from './feed-page';
 import { Auth } from '../../../core/services/auth';
@@ -9,6 +9,7 @@ import { Feed } from '../../../core/services/feed';
 import { Groups } from '../../../core/services/groups';
 import { Timetable } from '../../../core/services/timetable';
 import { CampusGroup } from '../../../core/models/group.model';
+import { TimetableResponse } from '../../../core/models/timetable.model';
 
 describe('FeedPage', () => {
   let component: FeedPage;
@@ -21,6 +22,12 @@ describe('FeedPage', () => {
     deleteComment: ReturnType<typeof vi.fn>;
     toggleReaction: ReturnType<typeof vi.fn>;
   };
+  let timetableApi: {
+    getStoredCourse: ReturnType<typeof vi.fn>;
+    normalizeCourse: ReturnType<typeof vi.fn>;
+    getTimetable: ReturnType<typeof vi.fn>;
+  };
+  let userProfile: WritableSignal<{ course: string; role: string } | null>;
 
   const group: CampusGroup = {
     id: 'group-1',
@@ -52,6 +59,12 @@ describe('FeedPage', () => {
       deleteComment: vi.fn(() => of(post)),
       toggleReaction: vi.fn(() => of(post)),
     };
+    userProfile = signal({ course: 'TIF25A', role: 'Student' });
+    timetableApi = {
+      getStoredCourse: vi.fn(() => 'TIF25A'),
+      normalizeCourse: vi.fn((course: string) => course.trim().toUpperCase()),
+      getTimetable: vi.fn(() => of(createTimetable([]))),
+    };
 
     await TestBed.configureTestingModule({
       imports: [FeedPage],
@@ -62,7 +75,7 @@ describe('FeedPage', () => {
           useValue: {
             displayName: signal('Alice'),
             userRole: signal('Student'),
-            userProfile: signal({ course: 'TIF25A', role: 'Student' }),
+            userProfile,
           },
         },
         {
@@ -75,11 +88,7 @@ describe('FeedPage', () => {
         },
         {
           provide: Timetable,
-          useValue: {
-            getStoredCourse: () => 'TIF25A',
-            normalizeCourse: (course: string) => course.trim().toUpperCase(),
-            getTimetable: () => of({ course: 'TIF25A', timezone: 'Europe/Berlin', days: [] }),
-          },
+          useValue: timetableApi,
         },
       ],
     }).compileComponents();
@@ -115,4 +124,75 @@ describe('FeedPage', () => {
 
     expect(feedApi.toggleReaction).toHaveBeenCalledWith('post-1', { emoji: '🚀' });
   });
+
+  it('loads and sorts the current day schedule', () => {
+    const laterEvent = createEvent('later', '2026-04-29T11:00:00+02:00', '2026-04-29T12:00:00+02:00');
+    const earlierEvent = createEvent('earlier', '2026-04-29T09:00:00+02:00', '2026-04-29T10:00:00+02:00');
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-29T08:00:00+02:00'));
+    timetableApi.getTimetable.mockReturnValue(of(createTimetable([laterEvent, earlierEvent])));
+
+    fixture.detectChanges();
+
+    expect(component['_scheduleCourse']()).toBe('TIF25A');
+    expect(component['_scheduleEvents']().map(event => event.id)).toEqual(['earlier', 'later']);
+    expect(component['_scheduleError']()).toBe('');
+
+    vi.useRealTimers();
+  });
+
+  it('shows a course selection action when no schedule course is available', () => {
+    userProfile.set(null);
+    timetableApi.getStoredCourse.mockReturnValue('');
+
+    fixture.detectChanges();
+
+    expect(timetableApi.getTimetable).not.toHaveBeenCalled();
+    expect(component['_scheduleError']()).toBe('Wähle im Stundenplan zuerst deinen Kurs aus.');
+  });
+
+  it('clears schedule events and shows an error when schedule loading fails', () => {
+    timetableApi.getTimetable.mockReturnValue(throwError(() => new Error('network')));
+
+    fixture.detectChanges();
+
+    expect(component['_scheduleEvents']()).toEqual([]);
+    expect(component['_scheduleError']()).toBe('Der Tagesplan konnte nicht geladen werden.');
+  });
+
+  it('clears stale feed errors on a successful reload and prevents duplicate posts', () => {
+    fixture.detectChanges();
+    component['_error'].set('Alter Fehler');
+
+    component['_loadFeed']();
+
+    expect(component['_error']()).toBe('');
+
+    component['updateContent']('Neuer Beitrag');
+    component['_isPosting'].set(true);
+    component['onPost']();
+
+    expect(feedApi.createPost).not.toHaveBeenCalled();
+  });
 });
+
+function createTimetable(events: ReturnType<typeof createEvent>[]): TimetableResponse {
+  return {
+    course: 'TIF25A',
+    timezone: 'Europe/Berlin',
+    days: [{ date: '2026-04-29', events }],
+  };
+}
+
+function createEvent(id: string, start: string, end: string) {
+  return {
+    id,
+    title: 'Software Engineering',
+    start,
+    end,
+    location: 'Aula',
+    description: null,
+    isAllDay: false,
+    isOnline: false,
+  };
+}

--- a/CampusConnect/frontend/src/app/features/feed/feed-page/feed-page.ts
+++ b/CampusConnect/frontend/src/app/features/feed/feed-page/feed-page.ts
@@ -28,6 +28,7 @@ export class FeedPage implements OnInit {
 
   protected readonly _posts = signal<FeedPost[]>([]);
   protected readonly _isLoading = signal(false);
+  protected readonly _isPosting = signal(false);
   protected readonly _error = signal('');
   protected readonly _newContent = signal('');
   protected readonly _commentDrafts = signal<Record<string, string>>({});
@@ -63,15 +64,16 @@ export class FeedPage implements OnInit {
 
   private _loadFeed(): void {
     this._isLoading.set(true);
+    this._error.set('');
     this._feedService.getFeed().subscribe({
-      next: posts => { this._posts.set(posts); this._isLoading.set(false); },
+      next: posts => { this._posts.set(posts); this._error.set(''); this._isLoading.set(false); },
       error: () => { this._error.set('Feed konnte nicht geladen werden.'); this._isLoading.set(false); },
     });
   }
 
   protected onPost(): void {
     const content = this._newContent().trim();
-    if (!content) return;
+    if (!content || this._isPosting()) return;
     const group = this._selectedGroup();
     if (!group) {
       this._error.set('Bitte wähle zuerst eine Gruppe aus.');
@@ -79,9 +81,10 @@ export class FeedPage implements OnInit {
     }
 
     this._error.set('');
+    this._isPosting.set(true);
     this._feedService.createPost({ content, groupId: group.id }).subscribe({
-      next: post => { this._posts.update(posts => [post, ...posts]); this._newContent.set(''); },
-      error: () => this._error.set('Beitrag konnte nicht erstellt werden.'),
+      next: post => { this._posts.update(posts => [post, ...posts]); this._newContent.set(''); this._isPosting.set(false); },
+      error: () => { this._error.set('Beitrag konnte nicht erstellt werden.'); this._isPosting.set(false); },
     });
   }
 

--- a/CampusConnect/frontend/src/app/features/grades/grades-page/grades-page.html
+++ b/CampusConnect/frontend/src/app/features/grades/grades-page/grades-page.html
@@ -19,20 +19,24 @@
     <form class="panel grade-form" #gradeForm="ngForm" (ngSubmit)="addGrade(gradeForm)">
       <h2>Neue Note eintragen</h2>
       @if (planModules().length > 0) {
-        <label>
-          Modul aus deinem Kursplan
-          <select name="selectedModuleCode" [(ngModel)]="selectedModuleCode" required>
-            @for (module of openPlanModules(); track module.code) {
-              <option [value]="module.code">{{ module.name }} · {{ module.ects }} ECTS</option>
-            }
-          </select>
-        </label>
-        @if (selectedPlanModule(); as selectedModule) {
-          <div class="selected-module">
-            <strong>{{ selectedModule.code }}</strong>
-            <span>{{ selectedModule.name }}</span>
-            <small>{{ examText(selectedModule) }}</small>
-          </div>
+        @if (hasOpenPlanModules()) {
+          <label>
+            Modul aus deinem Kursplan
+            <select name="selectedModuleCode" [(ngModel)]="selectedModuleCode" required>
+              @for (module of openPlanModules(); track module.code) {
+                <option [value]="module.code">{{ module.name }} · {{ module.ects }} ECTS</option>
+              }
+            </select>
+          </label>
+          @if (selectedPlanModule(); as selectedModule) {
+            <div class="selected-module">
+              <strong>{{ selectedModule.code }}</strong>
+              <span>{{ selectedModule.name }}</span>
+              <small>{{ examText(selectedModule) }}</small>
+            </div>
+          }
+        } @else {
+          <span class="form-note">Alle Module aus deinem Kursplan sind bereits erfasst.</span>
         }
       } @else {
         <label>
@@ -62,7 +66,7 @@
           </label>
         }
       </div>
-      <button type="submit" [disabled]="_isSubmitting()">Note speichern</button>
+      <button type="submit" [disabled]="_isSubmitting() || (planModules().length > 0 && !hasOpenPlanModules())">Note speichern</button>
       @if (_error()) {
         <span class="field-error">{{ _error() }}</span>
       }

--- a/CampusConnect/frontend/src/app/features/grades/grades-page/grades-page.spec.ts
+++ b/CampusConnect/frontend/src/app/features/grades/grades-page/grades-page.spec.ts
@@ -121,6 +121,24 @@ describe('GradesPage', () => {
     expect(gradesService.deleteGrade).toHaveBeenCalledWith('grade-1');
     expect(component['grades']()).toEqual([]);
   });
+
+  it('should not select a completed course-plan module when no open modules remain', () => {
+    plan = {
+      ...plan,
+      modules: plan.modules.map(module => ({ ...module, isCompleted: true, grade: 1.7 })),
+    };
+
+    component['_loadPlan']();
+
+    expect(component['openPlanModules']()).toEqual([]);
+    expect(component['selectedModuleCode']).toBe('');
+    expect(component['selectedPlanModule']()).toBeNull();
+
+    component['addGrade']();
+
+    expect(gradesService.addGrade).not.toHaveBeenCalled();
+    expect(component['_error']()).toBe('Alle Module aus deinem Kursplan sind bereits erfasst.');
+  });
 });
 
 function createSummary(grades: Grade[]): GradeSummary {

--- a/CampusConnect/frontend/src/app/features/grades/grades-page/grades-page.ts
+++ b/CampusConnect/frontend/src/app/features/grades/grades-page/grades-page.ts
@@ -42,6 +42,7 @@ export class GradesPage implements OnInit {
   protected readonly grades = computed(() => this._summary().grades);
   protected readonly planModules = computed(() => this._plan()?.modules ?? []);
   protected readonly openPlanModules = computed(() => this.planModules().filter(module => !module.isCompleted));
+  protected readonly hasOpenPlanModules = computed(() => this.openPlanModules().length > 0);
   protected readonly completedPlanModules = computed(() => this.planModules().filter(module => module.isCompleted).length);
   protected readonly totalEcts = computed(() => this._summary().totalEcts);
   protected readonly weightedAverage = computed(() => this.grades().length === 0 ? Number.NaN : this._summary().weightedAverage);
@@ -108,6 +109,11 @@ export class GradesPage implements OnInit {
     const hasPlan = this.planModules().length > 0;
     const moduleName = this.moduleName.trim();
 
+    if (hasPlan && !this.hasOpenPlanModules()) {
+      this._error.set('Alle Module aus deinem Kursplan sind bereits erfasst.');
+      return;
+    }
+
     if (hasPlan && !selectedModule) {
       this._error.set('Bitte wähle ein Modul aus deinem Kursplan aus.');
       return;
@@ -164,7 +170,7 @@ export class GradesPage implements OnInit {
   }
 
   protected selectedPlanModule(): GradePlanModule | null {
-    return this.planModules().find(module => module.code === this.selectedModuleCode) ?? null;
+    return this.openPlanModules().find(module => module.code === this.selectedModuleCode) ?? null;
   }
 
   protected examText(module: GradePlanModule): string {
@@ -279,7 +285,7 @@ export class GradesPage implements OnInit {
   }
 
   private nextOpenModuleCode(): string {
-    return this.openPlanModules()[0]?.code ?? this.planModules()[0]?.code ?? '';
+    return this.openPlanModules()[0]?.code ?? '';
   }
 
   private _readError(error: unknown, fallback: string): string {

--- a/CampusConnect/frontend/src/app/features/mensa/mensa-page/mensa-page.html
+++ b/CampusConnect/frontend/src/app/features/mensa/mensa-page/mensa-page.html
@@ -13,20 +13,19 @@
     <p class="mensa-page__state mensa-page__state--error">{{ _error() }}</p>
   } @else if (_menu().length > 0) {
     <div class="mensa-layout">
-      <aside class="mensa-days" aria-label="Speiseplantage">
+      <aside class="mensa-days" aria-label="Speiseplan-Tage">
         <div class="section-heading">
           <span>Woche</span>
           <strong>Tage</strong>
         </div>
 
-        <div class="mensa-days__list" role="tablist" aria-label="Speiseplantage">
+        <div class="mensa-days__list" aria-label="Speiseplan-Tage">
           @for (day of _menu(); track day.date; let index = $index) {
             <button
               class="mensa-days__item"
               type="button"
-              role="tab"
               [class.active]="_selectedDay() === index"
-              [attr.aria-selected]="_selectedDay() === index"
+              [attr.aria-current]="_selectedDay() === index ? 'date' : null"
               (click)="selectDay(index)">
               <span class="mensa-days__weekday">{{ day.date | date:'EEE':'':'de' }}</span>
               <span>

--- a/CampusConnect/frontend/src/app/features/mensa/mensa-page/mensa-page.spec.ts
+++ b/CampusConnect/frontend/src/app/features/mensa/mensa-page/mensa-page.spec.ts
@@ -45,4 +45,31 @@ describe('MensaPage', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should ignore day selections outside the loaded menu', () => {
+    component['selectDay'](99);
+
+    expect(component['_selectedDay']()).toBe(0);
+
+    component['selectDay'](-1);
+
+    expect(component['_selectedDay']()).toBe(0);
+  });
+
+  it('should derive readable category markers', () => {
+    expect(component['categoryMarker']('Essen 1')).toBe('E1');
+    expect(component['categoryMarker']('  ')).toBe('ME');
+  });
+
+  it('should fall back to the dish name when no pre-split name lines exist', () => {
+    expect(component['dishNameLines']({
+      name: 'Pasta mit Tomatensauce',
+      nameLines: [],
+      category: 'Essen 2',
+      priceStudent: 3.4,
+      allergens: null,
+      isVegetarian: true,
+      isVegan: false,
+    })).toEqual(['Pasta mit Tomatensauce']);
+  });
 });

--- a/CampusConnect/frontend/src/app/shared/ui/profile-hover-card/profile-hover-card.html
+++ b/CampusConnect/frontend/src/app/shared/ui/profile-hover-card/profile-hover-card.html
@@ -1,4 +1,4 @@
-<span class="profile-hover-card" tabindex="0">
+<span class="profile-hover-card" tabindex="0" [attr.aria-describedby]="profile() ? _tooltipId : null">
   <span class="profile-hover-card__trigger">
     @if (showAvatar()) {
       <span class="profile-hover-card__avatar" aria-hidden="true">{{ _initials() }}</span>
@@ -9,7 +9,7 @@
   </span>
 
   @if (profile(); as contact) {
-    <span class="profile-hover-card__panel" role="tooltip">
+    <span class="profile-hover-card__panel" role="tooltip" [id]="_tooltipId">
       <span class="profile-hover-card__header">
         <span class="profile-hover-card__avatar profile-hover-card__avatar--large" aria-hidden="true">{{ _initials() }}</span>
         <span>

--- a/CampusConnect/frontend/src/app/shared/ui/profile-hover-card/profile-hover-card.ts
+++ b/CampusConnect/frontend/src/app/shared/ui/profile-hover-card/profile-hover-card.ts
@@ -9,10 +9,13 @@ import { ContactProfile } from '../../../core/models/contact.model';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProfileHoverCard {
+  private static _nextTooltipId = 0;
+
   readonly profile = input<ContactProfile | null | undefined>(null);
   readonly displayName = input.required<string>();
   readonly showAvatar = input(false);
   readonly showName = input(true);
+  protected readonly _tooltipId = `profile-hover-card-${ProfileHoverCard._nextTooltipId++}`;
 
   protected readonly _initials = computed(() => {
     const source = this.profile()?.displayName || this.displayName();


### PR DESCRIPTION
Addresses remaining actionable Copilot review comments from the recent merged PRs into `main`.

Summary:
- Handles grade-plan API failures with clearer 400/404/503 responses and guards DHBW study-plan HTTP fetches against remote/network failures.
- Makes the in-memory group repository access synchronized and avoids mutating stored group instances in-place.
- Cleans up normalized user email lookup with `AsNoTracking()`.
- Fixes feed posting/loading state, stale feed errors, duplicate 401 redirects, grade-plan empty-open-module behavior, Mensa day navigation accessibility, and profile hover-card tooltip association.
- Adds focused frontend tests for the review-comment paths, including login-page coverage.

Notes:
- Kept `PdfPig` `0.1.14` because NuGet confirms it is the valid stable package ID in this repo; the suggested `UglyToad.PdfPig` `0.1.14` package does not exist on the configured feeds.
- Kept the current Swashbuckle 10 `Microsoft.OpenApi` / `AddSecurityRequirement(document => ...)` shape after checking current docs and validating with `dotnet build`.
- Did not persist JWTs in browser storage because the repository instructions explicitly require in-memory token storage.

Validation:
- `npm test -- --watch=false` passed: 31 files, 74 tests.
- `npm run build` passed.
- `dotnet restore .\CampusConnect.slnx` passed.
- `dotnet build .\CampusConnect.slnx` passed after stopping a stale local API process that was locking output DLLs.
- `dotnet test .\CampusConnect.slnx` passed: 69 tests.